### PR TITLE
Create deploy preview to save the state demoing Gridsome routing not behaving correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## Routing Issue Demo
+
+This branch is made so that I can get a deploy preview to show a case example of Gridsome's routing not working when an exact entry point is given as the URL to enter a Gridsome site.
+
 [![Netlify Status](https://api.netlify.com/api/v1/badges/79932a8f-4ecb-4b1e-a4ed-d75e72bdfb7a/deploy-status)](https://app.netlify.com/sites/puerhwtf/deploys) ![CodeQL](https://github.com/tonyketcham/puerh.wtf/workflows/CodeQL/badge.svg?branch=main) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftonyketcham%2Fpuerh.wtf.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Ftonyketcham%2Fpuerh.wtf?ref=badge_shield)
 
 # Pu-erh, wtf


### PR DESCRIPTION
Entering the site at a specific point such as `<example.com>/about` and then trying to navigate using g-link doesn't work.
Entering at `<example.com>` and navigating from there works.